### PR TITLE
Fix Port Mapping for Docker Container

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ For both installations you will need to:
 #### Running the server
 * Docker case: simply run the docker image (you need sudo access) `sudo docker run -t <image_name:tag>`
   running the docker image will launch the service on the default port 5000 so you need to expose this port to your client
-  or use the `--network host` option to run it on your localhost. For more information please see the [docker run network options]
-  (https://docs.docker.com/engine/reference/run/#network-settings)
+  (e.g. via `docker run --gpus all -p 5000:5000 <image_name:tag>`, the gpus flag will enable [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) GPU support.) 
+  or use the `--network host` option to run it on your localhost. For more information please see the [docker run network options](https://docs.docker.com/engine/reference/run/#network-settings)
 * Source installation: run server.py
 
 #### Running the client

--- a/server.py
+++ b/server.py
@@ -162,4 +162,4 @@ def bad_request(error):
 
 
 if __name__ == "__main__":
-    app.run(debug=False)
+    app.run(host='0.0.0.0', debug=False)


### PR DESCRIPTION
With this pull request, i have fixed port mapping for docker and added an example command to the readme.
Without this fix, the server will not respond to requests from outside the container.
(see https://stackoverflow.com/a/26434706/)